### PR TITLE
usr:chg: install ROS, initalize workspaces

### DIFF
--- a/rosProj/catkinPkg_main.yml
+++ b/rosProj/catkinPkg_main.yml
@@ -1,0 +1,18 @@
+---
+- name: create directory for catkin tools source files
+  vars:
+    catkin_root: /tmp/catkinPkg
+  file: path={{ catkin_root }}  state=directory recurse=yes
+
+- name: retrieve catkin tools package from source
+  vars:
+    catkin_root: /tmp/catkinPkg
+  git:
+    repo: https://github.com/catkin/catkin_tools.git
+    dest: "{{ catkin_root }}"
+
+- name: cd to catkin_root
+  vars:
+    catkin_root: /tmp/catkinPkg
+  become: yes
+  command: chdir=/tmp/catkinPkg pip install -r requirements.txt --upgrade

--- a/rosProj/index.html
+++ b/rosProj/index.html
@@ -1,0 +1,375 @@
+
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+  <!--
+    Modified from the Debian original for Ubuntu
+    Last updated: 2014-03-19
+    See: https://launchpad.net/bugs/1288690
+  -->
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+    <title>Apache2 Ubuntu Default Page: It works</title>
+    <style type="text/css" media="screen">
+  * {
+    margin: 0px 0px 0px 0px;
+    padding: 0px 0px 0px 0px;
+  }
+
+  body, html {
+    padding: 3px 3px 3px 3px;
+
+    background-color: #D8DBE2;
+
+    font-family: Verdana, sans-serif;
+    font-size: 11pt;
+    text-align: center;
+  }
+
+  div.main_page {
+    position: relative;
+    display: table;
+
+    width: 800px;
+
+    margin-bottom: 3px;
+    margin-left: auto;
+    margin-right: auto;
+    padding: 0px 0px 0px 0px;
+
+    border-width: 2px;
+    border-color: #212738;
+    border-style: solid;
+
+    background-color: #FFFFFF;
+
+    text-align: center;
+  }
+
+  div.page_header {
+    height: 99px;
+    width: 100%;
+
+    background-color: #F5F6F7;
+  }
+
+  div.page_header span {
+    margin: 15px 0px 0px 50px;
+
+    font-size: 180%;
+    font-weight: bold;
+  }
+
+  div.page_header img {
+    margin: 3px 0px 0px 40px;
+
+    border: 0px 0px 0px;
+  }
+
+  div.table_of_contents {
+    clear: left;
+
+    min-width: 200px;
+
+    margin: 3px 3px 3px 3px;
+
+    background-color: #FFFFFF;
+
+    text-align: left;
+  }
+
+  div.table_of_contents_item {
+    clear: left;
+
+    width: 100%;
+
+    margin: 4px 0px 0px 0px;
+
+    background-color: #FFFFFF;
+
+    color: #000000;
+    text-align: left;
+  }
+
+  div.table_of_contents_item a {
+    margin: 6px 0px 0px 6px;
+  }
+
+  div.content_section {
+    margin: 3px 3px 3px 3px;
+
+    background-color: #FFFFFF;
+
+    text-align: left;
+  }
+
+  div.content_section_text {
+    padding: 4px 8px 4px 8px;
+
+    color: #000000;
+    font-size: 100%;
+  }
+
+  div.content_section_text pre {
+    margin: 8px 0px 8px 0px;
+    padding: 8px 8px 8px 8px;
+
+    border-width: 1px;
+    border-style: dotted;
+    border-color: #000000;
+
+    background-color: #F5F6F7;
+
+    font-style: italic;
+  }
+
+  div.content_section_text p {
+    margin-bottom: 6px;
+  }
+
+  div.content_section_text ul, div.content_section_text li {
+    padding: 4px 8px 4px 16px;
+  }
+
+  div.section_header {
+    padding: 3px 6px 3px 6px;
+
+    background-color: #8E9CB2;
+
+    color: #FFFFFF;
+    font-weight: bold;
+    font-size: 112%;
+    text-align: center;
+  }
+
+  div.section_header_red {
+    background-color: #CD214F;
+  }
+
+  div.section_header_grey {
+    background-color: #9F9386;
+  }
+
+  .floating_element {
+    position: relative;
+    float: left;
+  }
+
+  div.table_of_contents_item a,
+  div.content_section_text a {
+    text-decoration: none;
+    font-weight: bold;
+  }
+
+  div.table_of_contents_item a:link,
+  div.table_of_contents_item a:visited,
+  div.table_of_contents_item a:active {
+    color: #000000;
+  }
+
+  div.table_of_contents_item a:hover {
+    background-color: #000000;
+
+    color: #FFFFFF;
+  }
+
+  div.content_section_text a:link,
+  div.content_section_text a:visited,
+   div.content_section_text a:active {
+    background-color: #DCDFE6;
+
+    color: #000000;
+  }
+
+  div.content_section_text a:hover {
+    background-color: #000000;
+
+    color: #DCDFE6;
+  }
+
+  div.validator {
+  }
+    </style>
+  </head>
+  <body>
+    <div class="main_page">
+      <div class="page_header floating_element">
+        <img src="/icons/ubuntu-logo.png" alt="Ubuntu Logo" class="floating_element"/>
+        <span class="floating_element">
+          Apache2 Ubuntu Default Page
+        </span>
+      </div>
+<!--      <div class="table_of_contents floating_element">
+        <div class="section_header section_header_grey">
+          TABLE OF CONTENTS
+        </div>
+        <div class="table_of_contents_item floating_element">
+          <a href="#about">About</a>
+        </div>
+        <div class="table_of_contents_item floating_element">
+          <a href="#changes">Changes</a>
+        </div>
+        <div class="table_of_contents_item floating_element">
+          <a href="#scope">Scope</a>
+        </div>
+        <div class="table_of_contents_item floating_element">
+          <a href="#files">Config files</a>
+        </div>
+      </div>
+-->
+      <div class="content_section floating_element">
+
+
+        <div class="section_header section_header_red">
+          <div id="about"></div>
+          It works!
+        </div>
+        <div class="content_section_text">
+          <p>
+                This is the default welcome page used to test the correct 
+                operation of the Apache2 server after installation on Ubuntu systems.
+                It is based on the equivalent page on Debian, from which the Ubuntu Apache
+                packaging is derived.
+                If you can read this page, it means that the Apache HTTP server installed at
+                this site is working properly. You should <b>replace this file</b> (located at
+                <tt>/var/www/html/index.html</tt>) before continuing to operate your HTTP server.
+          </p>
+
+
+          <p>
+                If you are a normal user of this web site and don't know what this page is
+                about, this probably means that the site is currently unavailable due to
+                maintenance.
+                If the problem persists, please contact the site's administrator.
+          </p>
+
+        </div>
+        <div class="section_header">
+          <div id="changes"></div>
+                Configuration Overview
+        </div>
+        <div class="content_section_text">
+          <p>
+                Ubuntu's Apache2 default configuration is different from the
+                upstream default configuration, and split into several files optimized for
+                interaction with Ubuntu tools. The configuration system is
+                <b>fully documented in
+                /usr/share/doc/apache2/README.Debian.gz</b>. Refer to this for the full
+                documentation. Documentation for the web server itself can be
+                found by accessing the <a href="/manual">manual</a> if the <tt>apache2-doc</tt>
+                package was installed on this server.
+
+          </p>
+          <p>
+                The configuration layout for an Apache2 web server installation on Ubuntu systems is as follows:
+          </p>
+          <pre>
+/etc/apache2/
+|-- apache2.conf
+|       `--  ports.conf
+|-- mods-enabled
+|       |-- *.load
+|       `-- *.conf
+|-- conf-enabled
+|       `-- *.conf
+|-- sites-enabled
+|       `-- *.conf
+          </pre>
+          <ul>
+                        <li>
+                           <tt>apache2.conf</tt> is the main configuration
+                           file. It puts the pieces together by including all remaining configuration
+                           files when starting up the web server.
+                        </li>
+
+                        <li>
+                           <tt>ports.conf</tt> is always included from the
+                           main configuration file. It is used to determine the listening ports for
+                           incoming connections, and this file can be customized anytime.
+                        </li>
+
+                        <li>
+                           Configuration files in the <tt>mods-enabled/</tt>,
+                           <tt>conf-enabled/</tt> and <tt>sites-enabled/</tt> directories contain
+                           particular configuration snippets which manage modules, global configuration
+                           fragments, or virtual host configurations, respectively.
+                        </li>
+
+                        <li>
+                           They are activated by symlinking available
+                           configuration files from their respective
+                           *-available/ counterparts. These should be managed
+                           by using our helpers
+                           <tt>
+                                <a href="http://manpages.debian.org/cgi-bin/man.cgi?query=a2enmod">a2enmod</a>,
+                                <a href="http://manpages.debian.org/cgi-bin/man.cgi?query=a2dismod">a2dismod</a>,
+                           </tt>
+                           <tt>
+                                <a href="http://manpages.debian.org/cgi-bin/man.cgi?query=a2ensite">a2ensite</a>,
+                                <a href="http://manpages.debian.org/cgi-bin/man.cgi?query=a2dissite">a2dissite</a>,
+                            </tt>
+                                and
+                           <tt>
+                                <a href="http://manpages.debian.org/cgi-bin/man.cgi?query=a2enconf">a2enconf</a>,
+                                <a href="http://manpages.debian.org/cgi-bin/man.cgi?query=a2disconf">a2disconf</a>
+                           </tt>. See their respective man pages for detailed information.
+                        </li>
+
+                        <li>
+                           The binary is called apache2. Due to the use of
+                           environment variables, in the default configuration, apache2 needs to be
+                           started/stopped with <tt>/etc/init.d/apache2</tt> or <tt>apache2ctl</tt>.
+                           <b>Calling <tt>/usr/bin/apache2</tt> directly will not work</b> with the
+                           default configuration.
+                        </li>
+          </ul>
+        </div>
+
+        <div class="section_header">
+            <div id="docroot"></div>
+                Document Roots
+        </div>
+
+        <div class="content_section_text">
+            <p>
+                By default, Ubuntu does not allow access through the web browser to
+                <em>any</em> file apart of those located in <tt>/var/www</tt>,
+                <a href="http://httpd.apache.org/docs/2.4/mod/mod_userdir.html">public_html</a>
+                directories (when enabled) and <tt>/usr/share</tt> (for web
+                applications). If your site is using a web document root
+                located elsewhere (such as in <tt>/srv</tt>) you may need to whitelist your
+                document root directory in <tt>/etc/apache2/apache2.conf</tt>.
+            </p>
+            <p>
+                The default Ubuntu document root is <tt>/var/www/html</tt>. You
+                can make your own virtual hosts under /var/www. This is different
+                to previous releases which provides better security out of the box.
+            </p>
+        </div>
+
+        <div class="section_header">
+          <div id="bugs"></div>
+                Reporting Problems
+        </div>
+        <div class="content_section_text">
+          <p>
+                Please use the <tt>ubuntu-bug</tt> tool to report bugs in the
+                Apache2 package with Ubuntu. However, check <a
+                href="https://bugs.launchpad.net/ubuntu/+source/apache2">existing
+                bug reports</a> before reporting a new bug.
+          </p>
+          <p>
+                Please report bugs specific to modules (such as PHP and others)
+                to respective packages, not to the web server itself.
+          </p>
+        </div>
+
+
+
+
+      </div>
+    </div>
+    <div class="validator">
+    </div>
+  </body>
+</html>
+

--- a/rosProj/inventory.txt
+++ b/rosProj/inventory.txt
@@ -1,0 +1,4 @@
+[eunosm3-cluster]
+129.114.33.151 ansible_ssh_user="cc"
+#129.114.33.220 ansible_ssh_user="cc"
+129.114.32.107 ansible_ssh_user="cc"

--- a/rosProj/main.BAK.txt
+++ b/rosProj/main.BAK.txt
@@ -1,0 +1,19 @@
+---
+- name: create directory for catkin tools source files
+  vars:
+    catkin_root: /tmp/catkinPkg
+  file: path={{ catkin_root }}  state=directory recurse=yes
+
+- name: change to directory for new catkin tools repo
+  vars:
+    catkin_repo_dir: /etc/apt/sources.list.d
+  become: yes
+  command: chdir={{ catkin_repo_dir}} touch ros-latest.list
+
+- name: create file for new repo
+  vars:
+    catkin_repo_file: /etc/apt/sources.list.d/ros-latest.list
+  file: path={{ catkin_repo_file }} state=touch
+
+- name: add catkin tools repo to /etc/apt/sources.list.d/ros.latest.list file
+  command: $ echo "deb http://packages.ros.org/ros/ubuntu xenial main" > /etc/apt/sources.list.d/ros-latest.list

--- a/rosProj/roles/catkinPkg/tasks/main.yml
+++ b/rosProj/roles/catkinPkg/tasks/main.yml
@@ -1,0 +1,8 @@
+---
+#- name: add the catkin tools repo
+#  become: true
+#  apt_repository: repo='deb http://packages.ros.org/ros/ubuntu xenial main' state=present
+
+- name: install catkin tools
+  become: true
+  apt: pkg=python-catkin-tools state=present

--- a/rosProj/roles/catkinPkg/tasks/mainBAK.yml
+++ b/rosProj/roles/catkinPkg/tasks/mainBAK.yml
@@ -1,0 +1,14 @@
+---
+- name: create directory for catkin tools source files
+  vars:
+    catkin_root: /tmp/catkinPkg
+  file: path={{ catkin_root }}  state=directory recurse=yes
+
+- name: create sources.list.d file for ROS if needed
+  copy:
+    content: ""
+    dest: /etc/apt/sources.list.d/ros-latest.list
+    force: no
+
+# - name: add catkin tools repo to /etc/apt/sources.list.d/ros-latest.list file
+#  command: $ echo "deb http://packages.ros.org/ros/ubuntu xenial main" > /etc/apt/sources.list.d/ros-latest.list

--- a/rosProj/roles/pipPkg/tasks/main.yml
+++ b/rosProj/roles/pipPkg/tasks/main.yml
@@ -1,0 +1,4 @@
+---
+- name: install pip package
+  become: yes
+  apt: name=python-pip  state=latest update_cache=yes

--- a/rosProj/roles/rosEnvSetup/tasks/main.yml
+++ b/rosProj/roles/rosEnvSetup/tasks/main.yml
@@ -1,0 +1,87 @@
+---
+- name: catkin workspace setup main
+  become_user: cc
+  file: path=/tmp/catkin_ws state=directory
+- name: catkin workspace setup src
+  become_user: cc
+  file: path=/tmp/catkin_ws/src state=directory
+- name: catkin workspace setup logs
+  become_user: cc
+  file: path=/tmp/catkin_ws/logs state=directory
+- name: catkin worskspace setup install
+  file: path=/tmp/catkin_ws/install state=directory
+
+- name: initialize  catkin workspace
+  shell: catkin config --init --extend /opt/ros/kinetic
+  become: yes
+  become_user: cc
+  args:
+    chdir: /tmp/catkin_ws
+    executable: /bin/bash
+
+- name: create catkin package
+  shell: catkin create pkg i524ros --rosdistro kinetic --catkin-deps std_msgs rospy roscpp
+  become: yes
+  become_user: cc
+  args:
+    chdir: /tmp/catkin_ws/src
+    executable: /bin/bash
+
+- name: build package(s)
+  shell: catkin build
+  become: yes
+  become_user: cc
+  args:
+    chdir: /tmp/catkin_ws/src
+    executable: /bin/bash
+
+#- name: setup caktin workspace
+#  become: true
+#  become_user: cc
+#  shell: "{{ item }}"
+#  with_items:
+#   - source /opt/ros/kinetic/setup.bash
+#   - mkdir -p /tmp/catkin_ws/src  #,logs,install creates=/tmp/catkin_ws03
+#   - mkdir /tmp/catkin_ws/logs
+#   - mkdir /tmp/catkin_ws/install
+#    - chdir=/tmp/catkin_ws  catkin config --init --extend /opt/ros/kinetic
+#    - chdir=/tmp/catkin_ws/src catkin create pkg i524ros --rosdistro kinetic --catkin-deps std_msgs rospy roscpp
+
+
+#- name: initialize newly-created workspace
+#  shell: chdir=/tmp/catkin_ws catkin init
+
+#- name: create rosI524 package
+
+#- name: add catkin source package; a hack to move the process forward
+#  shell: chdir=/tmp/catkin_ws/src git clone https://github.com/ros/catkin.git
+
+#- name: build rosI524  package
+#  shell: chdir=/tmp/catkin_ws/src catkin build
+
+## if done manually, use ' source ~/catkin_ws/devel/setup.bash '
+## must add to .bashrc b/c Ansible creates a new shell for each command
+## as a result, if not in .bashrc, would need to source file with each ansible command
+#- name: setup .bashrc to add newly-created directory to ROS_PACKAGE_PATH for evey new shell
+#  shell: echo "export ROS_PACKAGE_PATH=/opt/ros/kinetic/share:/tmp/catkin_ws/src/rosI524" >> /tmp/.bashrc
+#  shell: echo "source /tmp/catkin_ws/devel/setup.bash" >> /tmp/.bashrc
+
+#~~============================================================
+#   - echo "Hello, world." >> addAFile.txt
+
+
+#- name: initialize catkin workspace
+#  shell: catkin init
+
+#- name: set ROS_PACKAGE_PATH
+#  vars:
+#    home_directory: /home/cc
+#  lineinfile: 
+#    dest: '{{ home_directory }}/.bashrc'
+#    regexp: '^export ROS_PACKAGE_PATH=\/home\/cc\/catkin_ws03'
+#    line: 'export ROS_PACKAGE_PATH=$HOME/catkin_ws03:$ROS_PACKAGE_PATH'
+
+#- name: initialize catkin workspace
+#  command: "{{ item }}"
+#  with_items:
+#   - catkin init  

--- a/rosProj/roles/rosEnvSetup/tasks/main.yml.BAK
+++ b/rosProj/roles/rosEnvSetup/tasks/main.yml.BAK
@@ -1,0 +1,41 @@
+---
+- name: workspace setup part 01
+#  command: mkdir -p ~/catkin_ws/{src,logs,install}
+  file: path=/home/cc/catkin_ws state=directory owner=www-data group=www-data
+
+- name: determine if ROS_PACKAGE_PATH exists
+  replace: 
+    dest: /etc/environment
+    regexp: 'ROS_PACKAGE_PATH=(.*)'
+    replace: 'ROS_PACKAGE_PATH=\1'
+    register: checkIfPATHIsHere
+
+- name: create ROS_PACKAGE_PATH entry if applicable
+  vars:
+    ros_package_path: /home/cc/catkin_ws
+  lineinfile:
+    dest: /etc/environment
+    state: present
+    line: 'ROS_PACKAGE_PATH={{ ros_package_path }}'
+    regexp: ''
+    insertafter: EOF
+    when: checkIfPATHIsHere.changed==false
+
+- name: add {{ ros_package_path }} if one already exists
+  vars:
+    ros_package_path: /home/cc/catkin_ws
+  lineinfile:
+    dest: /etc/environment
+    state: present
+    backrefs: no
+    regexp: 'ROS_PACKAGE_PATH=(["])((?!.?{{ ros_package_path }}).?)(["])$'
+    line: 'ROS_PACKAGE_PATH=\1\2:{{ ros_package_path }}\3'
+    when: checkIfPATHIsHere.changed
+
+
+#- name ws setup part 02
+#  command: bash 'export ROS_PACKAGE_PATH=${HOME}/catkin_ws:${ROS_PACKAGE_PATH}'
+
+
+- name: change to newly-created workspace
+  command: chdir=/home/cc/catkin_ws ls

--- a/rosProj/roles/rosPkg/tasks/main.yml
+++ b/rosProj/roles/rosPkg/tasks/main.yml
@@ -1,0 +1,36 @@
+---
+- name: add ROS repo key ~total runtime: 15-20 minutes~
+  become: true
+  apt_key: id=421C365BD9FF1F717815A3895523BAEEB01FA116 keyserver=hkp://ha.pool.sks-keyservers.net:80
+
+- name: add ROS repository
+  become: true
+  apt_repository:
+    repo: 'deb http://packages.ros.org/ros/ubuntu xenial main'
+    state: present
+    update_cache: yes
+
+- name: install ROS ~runtime: 10 - 15 minutes~
+  become: true
+  apt:
+    pkg: ros-kinetic-desktop-full
+    state: present
+    update_cache: yes
+
+- name: initialize rosdep
+  shell: rosdep init
+
+- name: update rosdep
+  shell: rosdep update
+
+- name: add ROS setup.bash file to ~/.bashrc
+  shell: echo "source /opt/ros/kinetic/setup.bash" >> /home/cc/.bashrc
+
+#- name: source the ROS setup.bash file
+#  shell: source /opt/ros/kinetic/setup.bash
+
+- name: install rosinstall
+  apt:
+    pkg: python-rosinstall
+    state: present
+    update_cache: yes

--- a/rosProj/roles/rosPkg/tasks/main.yml.BAK01
+++ b/rosProj/roles/rosPkg/tasks/main.yml.BAK01
@@ -1,0 +1,12 @@
+---
+#- name: add ROS setup.bash file to ~/.bashrc
+#  shell: echo "source /opt/ros/kinetic/setup.bash" >> /home/cc/.bashrc
+
+#- name: source the ROS setup.bash file
+#  shell: source /opt/ros/kinetic/setup.bash
+
+- name: install rosinstall
+  apt:
+    pkg: python-rosinstall
+    state: present
+    update_cache: yes

--- a/rosProj/roles/rosPkg/tasks/main.yml.BAK2
+++ b/rosProj/roles/rosPkg/tasks/main.yml.BAK2
@@ -1,0 +1,19 @@
+---
+- name: source the ROS setup.bash file
+  command: chdir=/opt/ros/kinetic 'source setup.bash'
+#  args:
+#     chdir: /opt/ros/kinetic
+  become: true
+#  command: mkdir -p success01/success arg1 arg2
+#  args:
+#    chdir: /tmp
+#    creates: /tmp/success01/success
+#  shell: . /home/cc/.bashrc
+
+#  vars:
+#    ros_package_path: /opt/ros/kinetic/share
+#  lineinfile:
+#    dest: /etc/environment
+#    state: present
+#    line: 'ROS_PACKAGE_PATH={{ ros_package_path }}'
+#    insertafter: EOF

--- a/rosProj/roles/treePkg/tasks/main.yml
+++ b/rosProj/roles/treePkg/tasks/main.yml
@@ -1,0 +1,3 @@
+---
+- name: install tree package for directory viewing
+  apt: name=tree state=latest

--- a/rosProj/roles/updateApt/tasks/main.yml
+++ b/rosProj/roles/updateApt/tasks/main.yml
@@ -1,0 +1,4 @@
+---
+- name: update apt
+  become: yes
+  apt: update_cache=yes

--- a/rosProj/rosSetup.yml
+++ b/rosProj/rosSetup.yml
@@ -1,0 +1,20 @@
+---
+- hosts: eunosm3-cluster
+  become: true
+  roles:
+    - treePkg
+    - rosPkg
+    - catkinPkg
+    - rosEnvSetup
+
+
+
+#======================================================
+#  vars:
+#    doc_root: /home/cc/ansibleInstall
+#  tasks:
+#    - name: create custom document root
+#      file: path={{ doc_root }} state=directory owner=www-data group=www-data
+#
+#    - name: set up html file
+#      copy: src=index.html dest={{ doc_root }}/index.html owner=www-data group=www-data


### PR DESCRIPTION
This first pull request represents substantial development effort.  The Ansible playbook installs ROS, catkin_tools and tree on an arbitrary number of nodes as defined in the inventory.txt file.  It uses roles to break up the process by function, i.e., install and setup.  The install step includes three roles representing the three packages.  The setup function creates the necessary catkin workspace for package (program) development.