### PR TITLE
usr:chg: added StrictHostKeyChecking=no to begin file's rsync commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,13 @@ Prepatory Steps
 
 4. Ensure cloudmesh access
 	The process depends on cloudmesh_client commands.  You must have access to them in order for the process to succeed.
+
+Known Problems
+ 1. Simulation Software Fails
+ 	In some circumstances, the simulation software, Gazebo, will fail to launch properly.  The failure results from the method ROS' *roslaunch* command initializes Gazebo.  Possible solutions involve issuing the following commands from the terminal from the mybot_ws directory:
+ 	a. source  /home/cc/mybot_ws/devel/setup.bash
+ 	   rosrun gazebo_ros gzclient
+ 	   roslaunch mybot_gazebo mybot_world.launch
+ 	b. source /home/cc/mybot_ws/devel/setup.bash
+ 	   killall gzserver
+ 	   roslaunch mybot_gazebo mybot_world.launch

--- a/rosProjFinal/begin
+++ b/rosProjFinal/begin
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 
 # wget https://raw.githubusercontent.com/cloudmesh/cloudmesh.ros/master/rosProjFinal/begin
-
 #create and prepare a three-node cluster
 cm cluster define -n rosA1 -c 3
 cm cluster allocate
@@ -64,9 +63,9 @@ echo $node03_stat_ip" ansible_ssh_user=\"cc\"" >> ~/inventory.txt
 #use wget to place the rosSetup.yml file and inventory.txt file on the master node
 
 #add addMeToHostFiles.list to each cluster node
-rsync ~/addMeToHostFiles.list cc@$node01_ip:/home/cc
-rsync ~/addMeToHostFiles.list cc@$node02_ip:/home/cc
-rsync ~/addMeToHostFiles.list cc@$node03_ip:/home/cc
+rsync -e "ssh -o StrictHostKeyChecking=no" ~/addMeToHostFiles.list cc@$node01_ip:/home/cc
+rsync -e "ssh -o StrictHostKeyChecking=no" ~/addMeToHostFiles.list cc@$node02_ip:/home/cc
+rsync -e "ssh -o StrictHostKeyChecking=no" ~/addMeToHostFiles.list cc@$node03_ip:/home/cc
 
 #ROS robot files
 echo "README: Placing ROS files in ~/mybot_ws on master  node"


### PR DESCRIPTION
also added a bit to the README.md regarding the possible pitfalls of the project, like Gazebo failing to launch properly.